### PR TITLE
fix: improve error ui layout

### DIFF
--- a/src/components/renderer/FramedDocumentRenderer.tsx
+++ b/src/components/renderer/FramedDocumentRenderer.tsx
@@ -120,7 +120,7 @@ export function FramedDocumentRenderer<D extends OpenAttestationDocument | Signe
     <DomListener onUpdate={(height) => toHost.current(updateHeight(height))}>
       <HostConnector dispatch={dispatch} onConnected={onConnected}>
         {document && Template && (
-          <div className="frameless-tabs" id="rendered-certificate">
+          <div className="container" id="rendered-certificate">
             <Template
               document={document}
               wrappedDocument={rawDocument}

--- a/src/components/renderer/PdfRenderer.tsx
+++ b/src/components/renderer/PdfRenderer.tsx
@@ -50,15 +50,17 @@ export const PdfRenderer: FunctionComponent<Renderer> = ({ attachment }) => {
           background: "rgba(247, 248, 252, 1)",
           border: "1px solid rgba(231, 234, 236, 1)",
           borderRadius: "8px",
+          margin: "0 auto",
         }}
       >
-        <img src={attachmentErrorIcon} alt="Crash Icon" style={{ width: "120px", height: "120px" }} />
+        <img src={attachmentErrorIcon} alt="Crash Icon" style={{ width: "120px", height: "120px", margin: "0 auto" }} />
         <h3
           style={{
             fontFamily: "Gilroy",
             fontWeight: 700,
             fontSize: "20px",
             lineHeight: "24px",
+            margin: "15px 0",
           }}
         >
           Unable to Load Attachment


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the framed document view container to use a standardized layout class, improving visual consistency across renderers without altering behavior.
  * Refined spacing in the PDF viewer’s error state, adding margins around the container and error image plus extra vertical space for the heading to enhance readability.
  * No functional changes or data handling updates; adjustments are purely visual to align with design standards and improve overall presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->